### PR TITLE
Add x-ref between AMD CPU matrix and vendor response sections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,9 @@ is being read.
 
 ### AMD
 
-| CPU/µArch                      | MISPREDICT | BTI   | PRIV-LOAD | PRIV-REG |
-| ------------------------------ | ---------- | ----- | --------- | -------- |
-| Ryzen                          | Y          | Y?\*  | N         |          |
-
-\* = see [Vendor Response – AMD](#amd-1) section.
+| CPU/µArch                      | MISPREDICT | BTI                      | PRIV-LOAD | PRIV-REG |
+| ------------------------------ | ---------- | ------------------------ | --------- | -------- |
+| Ryzen                          | Y          | Y?<sup>[1](#amd-1)</sup> | N         |          |
 
 ### ARM
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ is being read.
 
 | CPU/µArch                      | MISPREDICT | BTI   | PRIV-LOAD | PRIV-REG |
 | ------------------------------ | ---------- | ----- | --------- | -------- |
-| Ryzen                          | Y          | Y?    | N         |          |
+| Ryzen                          | Y          | Y?\*  | N         |          |
+
+\* = see [Vendor Response – AMD](#amd-1) section.
 
 ### ARM
 


### PR DESCRIPTION
So that people wondering what the `?` means have a link to that.